### PR TITLE
docs: remove unnecessary git repository cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ```Shell
 cd ~/AppData/Roaming/FlowLauncher/Themes
-git clone git@github.com:abhidahal/onsetGlaze.flow.git .
+wget https://raw.githubusercontent.com/abhidahal/onsetGlaze.flow/main/OnsetGlaze.xaml
 ```
 
 >Go to Flowlauncher setting>Theme and select OnsetGlaze as your theme.


### PR DESCRIPTION
Cloning the entire repository creates a `.git` folder and a `README.md` file which are both unnecessary and might even cause conflicts if or when another theme is later installed at the same location.